### PR TITLE
<feat> : 도메인 설계 완료

### DIFF
--- a/src/main/java/com/hhp/precourse/FundamentalCrudApplication.java
+++ b/src/main/java/com/hhp/precourse/FundamentalCrudApplication.java
@@ -2,8 +2,10 @@ package com.hhp.precourse;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class FundamentalCrudApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/hhp/precourse/domain/Member.java
+++ b/src/main/java/com/hhp/precourse/domain/Member.java
@@ -1,0 +1,43 @@
+package com.hhp.precourse.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Member {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    private String stringId;
+
+    private String name;
+
+    private String encryptedPw;
+
+    private String email;
+
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
+    private List<Post> posts = new ArrayList<>();
+
+    @Builder
+    public Member(String stringId, String name, String encryptedPw, String email){
+        this.stringId = stringId;
+        this.name = name;
+        this.encryptedPw = encryptedPw;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/hhp/precourse/domain/Post.java
+++ b/src/main/java/com/hhp/precourse/domain/Post.java
@@ -1,0 +1,59 @@
+package com.hhp.precourse.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class) // 수정 날짜 전역으로 처리하기 위해 EntityListener 적용.
+public class Post {
+
+    @Id @GeneratedValue
+    @Column(name = "post_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member author;
+
+    private String title;
+
+    private String body;
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime lastModifiedDate;
+
+    private String postPw; // 6자리 정수
+
+
+    /* Utility Methods */
+
+    /**
+     * JPA Dirty Checking을 이용한 게시글 수정 적용 메서드.
+     * <br></br>
+     * 비밀번호에 대한 검증은 Service 단에서 이루어진다.
+     */
+    public void updatePost(String newTitle, String newBody){
+        this.title = newTitle;
+        this.body = newBody;
+    }
+
+}


### PR DESCRIPTION
# 요약
 1. 도메인 설계
 > - `Member`
 > - `Post` : `@EnableJpaAuditing` 과 `@EntityListener` 를 활용하여 마지막 수정 시점 및 생성 시점 자동 기록.
 
  2. 전체 프로젝트 구조 세팅
   - `domain`, `repository`, `service`, `controller` 네 가지의 패키지 구조를 갖도록 세팅 완료.