### PR TITLE
<feat> Domain 수정 및 Repository 설계 완료

### DIFF
--- a/src/main/java/com/hhp/precourse/domain/Member.java
+++ b/src/main/java/com/hhp/precourse/domain/Member.java
@@ -6,7 +6,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
@@ -16,12 +18,17 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(indexes = {
+        @Index(name = "idx_stringId", columnList = "stringId")
+}
+)
 public class Member {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     private Long id;
 
+    @Column(nullable = false, unique = true)
     private String stringId;
 
     private String name;

--- a/src/main/java/com/hhp/precourse/domain/Post.java
+++ b/src/main/java/com/hhp/precourse/domain/Post.java
@@ -6,8 +6,10 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +21,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class) // 수정 날짜 전역으로 처리하기 위해 EntityListener 적용.
+@Table(indexes = {
+        @Index(name = "idx_lastModified_date", columnList = "lastModifiedDate")
+}
+)
 public class Post {
 
     @Id @GeneratedValue

--- a/src/main/java/com/hhp/precourse/repository/member/MemberRepository.java
+++ b/src/main/java/com/hhp/precourse/repository/member/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.hhp.precourse.repository.member;
+
+import com.hhp.precourse.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/hhp/precourse/repository/post/PostRepository.java
+++ b/src/main/java/com/hhp/precourse/repository/post/PostRepository.java
@@ -1,0 +1,10 @@
+package com.hhp.precourse.repository.post;
+
+import com.hhp.precourse.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    Page<Post> findAll(Pageable pageable);
+}


### PR DESCRIPTION
# 요약

1. Domain 수정
> - `Member` 의 `stringId` 필드에 대해 DB 인덱스 생성.
2. Repository 설계
> - `PostRepository` : `Post` 가 페이지 단위로 전체 조회가 이루어질 수 있도록 Pagination 적용